### PR TITLE
feat: Add SGR-Pixels mouse mode (DECSET 1016)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3365,10 +3365,18 @@ Make sure seatd/logind is running and you're on an active VT."
                                 input::BTN_RIGHT => 2,
                                 _ => 0,
                             };
+                            let pixel_coords = if term.mouse_sgr_pixels() {
+                                let px = ((*x - mouse_offset_x).max(0.0)) as u32;
+                                let py = ((*y - mouse_offset_y).max(0.0)) as u32;
+                                Some((px, py))
+                            } else {
+                                None
+                            };
                             let _ = term.send_mouse_press(
                                 btn,
                                 col.min(grid_cols.saturating_sub(1)),
                                 row.min(grid_rows.saturating_sub(1)),
+                                pixel_coords,
                             );
                             mouse_button_held = Some(btn);
                         } else if *button == input::BTN_LEFT {
@@ -3426,10 +3434,18 @@ Make sure seatd/logind is running and you're on an active VT."
 
                         // Send move event if mouse mode is enabled
                         if term.mouse_mode_enabled() {
+                            let pixel_coords = if term.mouse_sgr_pixels() {
+                                let px = ((*x - mouse_offset_x).max(0.0)) as u32;
+                                let py = ((*y - mouse_offset_y).max(0.0)) as u32;
+                                Some((px, py))
+                            } else {
+                                None
+                            };
                             let _ = term.send_mouse_move(
                                 col.min(grid_cols.saturating_sub(1)),
                                 row.min(grid_rows.saturating_sub(1)),
                                 mouse_button_held,
+                                pixel_coords,
                             );
                         } else if mouse_selecting {
                             // Dragging: Update selection range
@@ -3461,10 +3477,18 @@ Make sure seatd/logind is running and you're on an active VT."
                                 input::BTN_RIGHT => 2,
                                 _ => 0,
                             };
+                            let pixel_coords = if term.mouse_sgr_pixels() {
+                                let px = ((*x - mouse_offset_x).max(0.0)) as u32;
+                                let py = ((*y - mouse_offset_y).max(0.0)) as u32;
+                                Some((px, py))
+                            } else {
+                                None
+                            };
                             let _ = term.send_mouse_release(
                                 btn,
                                 col.min(grid_cols.saturating_sub(1)),
                                 row.min(grid_rows.saturating_sub(1)),
+                                pixel_coords,
                             );
                         } else if *button == input::BTN_LEFT {
                             // Left button release: Confirm selection + auto copy
@@ -3492,10 +3516,18 @@ Make sure seatd/logind is running and you're on an active VT."
 
                         if use_mouse_wheel {
                             let d = if *delta < 0.0 { -1i8 } else { 1i8 };
+                            let pixel_coords = if term.mouse_sgr_pixels() {
+                                let px = ((*x - mouse_offset_x).max(0.0)) as u32;
+                                let py = ((*y - mouse_offset_y).max(0.0)) as u32;
+                                Some((px, py))
+                            } else {
+                                None
+                            };
                             let _ = term.send_mouse_wheel(
                                 d,
                                 col.min(grid_cols.saturating_sub(1)),
                                 row.min(grid_rows.saturating_sub(1)),
+                                pixel_coords,
                             );
                         } else {
                             // Scroll accumulation (negative=up/history, positive=down/live)

--- a/src/main.rs
+++ b/src/main.rs
@@ -748,6 +748,24 @@ fn draw_rounded_corner(
     true
 }
 
+/// Compute pane-relative pixel coordinates for SGR-Pixels mode (1016).
+/// Returns `Some((px, py))` when the mode is active, `None` otherwise.
+fn sgr_pixel_coords(
+    term: &terminal::Terminal,
+    x: f64,
+    y: f64,
+    offset_x: f64,
+    offset_y: f64,
+) -> Option<(u32, u32)> {
+    if term.mouse_sgr_pixels() {
+        let px = (x - offset_x).max(0.0) as u32;
+        let py = (y - offset_y).max(0.0) as u32;
+        Some((px, py))
+    } else {
+        None
+    }
+}
+
 /// Auto-detect DRM device with connected display
 ///
 /// Probes each /dev/dri/card* device and returns the first one
@@ -3365,13 +3383,7 @@ Make sure seatd/logind is running and you're on an active VT."
                                 input::BTN_RIGHT => 2,
                                 _ => 0,
                             };
-                            let pixel_coords = if term.mouse_sgr_pixels() {
-                                let px = ((*x - mouse_offset_x).max(0.0)) as u32;
-                                let py = ((*y - mouse_offset_y).max(0.0)) as u32;
-                                Some((px, py))
-                            } else {
-                                None
-                            };
+                            let pixel_coords = sgr_pixel_coords(term, *x, *y, mouse_offset_x, mouse_offset_y);
                             let _ = term.send_mouse_press(
                                 btn,
                                 col.min(grid_cols.saturating_sub(1)),
@@ -3434,13 +3446,7 @@ Make sure seatd/logind is running and you're on an active VT."
 
                         // Send move event if mouse mode is enabled
                         if term.mouse_mode_enabled() {
-                            let pixel_coords = if term.mouse_sgr_pixels() {
-                                let px = ((*x - mouse_offset_x).max(0.0)) as u32;
-                                let py = ((*y - mouse_offset_y).max(0.0)) as u32;
-                                Some((px, py))
-                            } else {
-                                None
-                            };
+                            let pixel_coords = sgr_pixel_coords(term, *x, *y, mouse_offset_x, mouse_offset_y);
                             let _ = term.send_mouse_move(
                                 col.min(grid_cols.saturating_sub(1)),
                                 row.min(grid_rows.saturating_sub(1)),
@@ -3477,13 +3483,7 @@ Make sure seatd/logind is running and you're on an active VT."
                                 input::BTN_RIGHT => 2,
                                 _ => 0,
                             };
-                            let pixel_coords = if term.mouse_sgr_pixels() {
-                                let px = ((*x - mouse_offset_x).max(0.0)) as u32;
-                                let py = ((*y - mouse_offset_y).max(0.0)) as u32;
-                                Some((px, py))
-                            } else {
-                                None
-                            };
+                            let pixel_coords = sgr_pixel_coords(term, *x, *y, mouse_offset_x, mouse_offset_y);
                             let _ = term.send_mouse_release(
                                 btn,
                                 col.min(grid_cols.saturating_sub(1)),
@@ -3516,13 +3516,7 @@ Make sure seatd/logind is running and you're on an active VT."
 
                         if use_mouse_wheel {
                             let d = if *delta < 0.0 { -1i8 } else { 1i8 };
-                            let pixel_coords = if term.mouse_sgr_pixels() {
-                                let px = ((*x - mouse_offset_x).max(0.0)) as u32;
-                                let py = ((*y - mouse_offset_y).max(0.0)) as u32;
-                                Some((px, py))
-                            } else {
-                                None
-                            };
+                            let pixel_coords = sgr_pixel_coords(term, *x, *y, mouse_offset_x, mouse_offset_y);
                             let _ = term.send_mouse_wheel(
                                 d,
                                 col.min(grid_cols.saturating_sub(1)),

--- a/src/terminal/grid.rs
+++ b/src/terminal/grid.rs
@@ -924,6 +924,7 @@ impl Grid {
         // Reset mouse modes
         self.modes.mouse_mode = MouseMode::None;
         self.modes.mouse_sgr = false;
+        self.modes.mouse_sgr_pixels = false;
 
         // Reset other enhanced modes
         self.modes.bracketed_paste = false;

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1818,15 +1818,46 @@ impl Terminal {
         self.grid.modes.mouse_mode != grid::MouseMode::None
     }
 
+    /// Check if SGR-Pixels mouse mode (1016) is enabled
+    pub fn mouse_sgr_pixels(&self) -> bool {
+        self.grid.modes.mouse_sgr_pixels
+    }
+
     /// Encode and send mouse event to PTY
     /// cb: button code
-    /// col, row: 0-indexed coordinates
+    /// col, row: 0-indexed cell coordinates
+    /// pixel_coords: optional (px, py) pixel coordinates for SGR-Pixels mode (1016)
     /// press: true for press (M), false for release (m) in SGR mode
-    fn send_mouse_event(&self, cb: u8, col: usize, row: usize, press: bool) -> Result<()> {
-        let cx = (col + 1).min(223);
-        let cy = (row + 1).min(223);
-
-        if self.grid.modes.mouse_sgr {
+    fn send_mouse_event(
+        &self,
+        cb: u8,
+        col: usize,
+        row: usize,
+        pixel_coords: Option<(u32, u32)>,
+        press: bool,
+    ) -> Result<()> {
+        if self.grid.modes.mouse_sgr_pixels {
+            // SGR-Pixels mode (1016): use pixel coordinates with SGR format
+            let (px, py) = pixel_coords.unwrap_or_else(|| {
+                // Fallback: approximate pixel coords from cell coords
+                // This shouldn't normally happen if the caller provides pixel coords
+                let cell_w = self.grid.cols().max(1);
+                let cell_h = self.grid.rows().max(1);
+                ((col * cell_w) as u32, (row * cell_h) as u32)
+            });
+            let suffix = if press { 'M' } else { 'm' };
+            let seq = format!("\x1b[<{};{};{}{}", cb, px, py, suffix);
+            trace!(
+                "Mouse event → PTY (SGR-Pixels): cb={} px={} py={} {}",
+                cb,
+                px,
+                py,
+                suffix
+            );
+            self.pty.write(seq.as_bytes())?;
+        } else if self.grid.modes.mouse_sgr {
+            let cx = (col + 1).min(223);
+            let cy = (row + 1).min(223);
             let suffix = if press { 'M' } else { 'm' };
             let seq = format!("\x1b[<{};{};{}{}", cb, cx, cy, suffix);
             trace!(
@@ -1838,6 +1869,8 @@ impl Terminal {
             );
             self.pty.write(seq.as_bytes())?;
         } else {
+            let cx = (col + 1).min(223);
+            let cy = (row + 1).min(223);
             let bytes = [0x1b, b'[', b'M', cb + 32, (cx as u8) + 32, (cy as u8) + 32];
             trace!("Mouse event → PTY (X10): cb={} col={} row={}", cb, cx, cy);
             self.pty.write(&bytes)?;
@@ -1847,31 +1880,52 @@ impl Terminal {
 
     /// Send mouse button press event to PTY
     /// button: 0=left, 1=middle, 2=right
-    /// col, row: 0-indexed
-    pub fn send_mouse_press(&self, button: u8, col: usize, row: usize) -> Result<()> {
+    /// col, row: 0-indexed cell coordinates
+    /// pixel_coords: optional (px, py) for SGR-Pixels mode (1016)
+    pub fn send_mouse_press(
+        &self,
+        button: u8,
+        col: usize,
+        row: usize,
+        pixel_coords: Option<(u32, u32)>,
+    ) -> Result<()> {
         if self.grid.modes.mouse_mode == grid::MouseMode::None {
             return Ok(());
         }
-        self.send_mouse_event(button, col, row, true)
+        self.send_mouse_event(button, col, row, pixel_coords, true)
     }
 
     /// Send mouse button release event to PTY
-    pub fn send_mouse_release(&self, button: u8, col: usize, row: usize) -> Result<()> {
+    /// pixel_coords: optional (px, py) for SGR-Pixels mode (1016)
+    pub fn send_mouse_release(
+        &self,
+        button: u8,
+        col: usize,
+        row: usize,
+        pixel_coords: Option<(u32, u32)>,
+    ) -> Result<()> {
         if self.grid.modes.mouse_mode == grid::MouseMode::None {
             return Ok(());
         }
 
-        if self.grid.modes.mouse_sgr {
-            // SGR format uses original button with lowercase 'm'
-            self.send_mouse_event(button, col, row, false)
+        if self.grid.modes.mouse_sgr || self.grid.modes.mouse_sgr_pixels {
+            // SGR/SGR-Pixels format uses original button with lowercase 'm'
+            self.send_mouse_event(button, col, row, pixel_coords, false)
         } else {
             // Normal format: button 3 means release
-            self.send_mouse_event(3, col, row, true)
+            self.send_mouse_event(3, col, row, None, true)
         }
     }
 
     /// Send mouse move event to PTY (in ButtonEvent/AnyEvent mode)
-    pub fn send_mouse_move(&self, col: usize, row: usize, button_held: Option<u8>) -> Result<()> {
+    /// pixel_coords: optional (px, py) for SGR-Pixels mode (1016)
+    pub fn send_mouse_move(
+        &self,
+        col: usize,
+        row: usize,
+        button_held: Option<u8>,
+        pixel_coords: Option<(u32, u32)>,
+    ) -> Result<()> {
         // AnyEvent (1003) or ButtonEvent (1002) + button held only
         match self.grid.modes.mouse_mode {
             grid::MouseMode::AnyEvent => {}
@@ -1885,19 +1939,26 @@ impl Terminal {
             None => 35,        // motion only
         };
 
-        self.send_mouse_event(cb, col, row, true)
+        self.send_mouse_event(cb, col, row, pixel_coords, true)
     }
 
     /// Send mouse wheel event to PTY
     /// delta: positive=down, negative=up
-    pub fn send_mouse_wheel(&self, delta: i8, col: usize, row: usize) -> Result<()> {
+    /// pixel_coords: optional (px, py) for SGR-Pixels mode (1016)
+    pub fn send_mouse_wheel(
+        &self,
+        delta: i8,
+        col: usize,
+        row: usize,
+        pixel_coords: Option<(u32, u32)>,
+    ) -> Result<()> {
         if self.grid.modes.mouse_mode == grid::MouseMode::None {
             return Ok(());
         }
 
         // button code: 64=up, 65=down
         let cb = if delta < 0 { 64 } else { 65 };
-        self.send_mouse_event(cb, col, row, true)
+        self.send_mouse_event(cb, col, row, pixel_coords, true)
     }
 
     /// Get cell for display row (considering scroll_offset)


### PR DESCRIPTION
## Summary

Add support for SGR-Pixels mouse mode (mode 1016), which reports mouse coordinates in pixel units rather than cell units using the SGR format (`CSI < Pb ; Px ; Py M/m`).

Closes #3

## Changes

- **`src/terminal/mod.rs`**: Add `mouse_sgr_pixels` flag handling, extend `send_mouse_event` and public mouse methods (`send_mouse_press`, `send_mouse_release`, `send_mouse_move`, `send_mouse_wheel`) with optional `pixel_coords` parameter for 1016 mode
- **`src/terminal/grid.rs`**: Reset `mouse_sgr_pixels` flag on terminal reset
- **`src/main.rs`**: Extract `sgr_pixel_coords` helper to compute pane-relative pixel coordinates, pass pixel coords to all mouse event calls

## Why

bcon reads mouse coordinates directly from evdev in pixel units, making it a natural fit for SGR-Pixels mode. Applications that need sub-cell precision (image viewers, graphical TUI tools) benefit from this.

## Reference

- [XTerm Control Sequences - SGR-Pixels](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html)

## Test plan

- [x] Verified with `printf '\e[?1016;1006h'` and mouse click/drag/scroll reports pixel coordinates
- [x] Standard SGR mode (1006) still works correctly
- [x] X10 legacy mode unaffected
- [x] Terminal reset clears SGR-Pixels mode