### PR TITLE
fix(graphics): repair chafa rendering and mpv kitty streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bcon"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcon"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 authors = ["Hironobu Sano"]
 description = "GPU-accelerated terminal emulator for Linux console"

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ https://github.com/user-attachments/assets/ebff498c-25b7-4662-8750-8d6e35661963
 - **HDR Detection**: Automatic HDR capability detection from EDID
 
 ### Graphics
-- **Sixel Graphics**: Display images in terminal
+- **Sixel Graphics**: Display images and video in terminal
 - **Kitty Graphics Protocol**: Fast image transfer (direct, file, shared memory)
+- **Video Playback**: `mpv --vo=kitty` for near-realtime terminal video playback
 
 ### Terminal
 - **Scrollback**: Configurable scrollback buffer (default: 10,000 lines)

--- a/src/terminal/grid.rs
+++ b/src/terminal/grid.rs
@@ -2535,10 +2535,7 @@ impl Grid {
                 if p.overlay {
                     return true;
                 }
-                if p.z == z_index
-                    && p.width_cells == width_cells
-                    && p.height_cells == height_cells
-                {
+                if p.z == z_index {
                     if reuse_pos.is_none() {
                         reuse_pos = Some((p.row, p.col));
                     }

--- a/src/terminal/grid.rs
+++ b/src/terminal/grid.rs
@@ -2518,36 +2518,49 @@ impl Grid {
             // rewrite or a newline wrote the first cell after placement).
             let mut new_row = self.cursor_row as u64 + self.scrollback_total;
             let mut new_col = self.cursor_col;
-            // `mpv --vo=sixel` resets the cursor to the same cell before each
-            // frame, but its status-display thread may interleave text after
-            // the positioning CUP, advancing the cursor past the intended
-            // column. If an existing same-dimension, same-z placement exists,
-            // reuse its position — the client clearly intended to replace
-            // that exact frame.
-            // Deduplicate for video streaming: `mpv --vo=sixel` sends
-            // identically-sized frames but mpv's status thread may have
-            // shifted the cursor between frames, so their positions differ
-            // slightly. Match by (z, width, height) to catch these.
-            // When a match is found, reuse the FIRST correct position so
-            // subsequent frames don't drift.
-            let mut reuse_pos: Option<(u64, usize)> = None;
-            self.image_placements.retain(|p| {
-                if p.overlay {
-                    return true;
-                }
-                if p.z == z_index {
+            // Sixel video streaming dedup (z < 0 only): mpv --vo=sixel
+            // sends frames at z=-1 with cursor positions corrupted by
+            // interleaved status text. Reuse the first frame's position.
+            // For z >= 0 (Kitty graphics, static sixel), just remove
+            // fully-covered placements without position reuse — apps like
+            // yazi place different images at different positions.
+            if z_index < 0 {
+                let mut reuse_pos: Option<(u64, usize)> = None;
+                self.image_placements.retain(|p| {
+                    if p.overlay || p.z != z_index {
+                        return true;
+                    }
                     if reuse_pos.is_none() {
                         reuse_pos = Some((p.row, p.col));
                     }
                     superseded.push(p.id);
                     false
-                } else {
-                    true
+                });
+                if let Some((prev_row, prev_col)) = reuse_pos {
+                    new_row = prev_row;
+                    new_col = prev_col;
                 }
-            });
-            if let Some((prev_row, prev_col)) = reuse_pos {
-                new_row = prev_row;
-                new_col = prev_col;
+            } else {
+                // z >= 0: remove fully-covered placements at same z
+                let new_row_end = new_row + height_cells as u64;
+                let new_col_end = new_col + width_cells;
+                self.image_placements.retain(|p| {
+                    if p.overlay || p.z != z_index {
+                        return true;
+                    }
+                    let p_row_end = p.row + p.height_cells as u64;
+                    let p_col_end = p.col + p.width_cells;
+                    let fully_covered = p.row >= new_row
+                        && p_row_end <= new_row_end
+                        && p.col >= new_col
+                        && p_col_end <= new_col_end;
+                    if fully_covered {
+                        superseded.push(p.id);
+                        false
+                    } else {
+                        true
+                    }
+                });
             }
 
             let placement = ImagePlacement {

--- a/src/terminal/grid.rs
+++ b/src/terminal/grid.rs
@@ -2525,16 +2525,28 @@ impl Grid {
             // fully-covered placements without position reuse — apps like
             // yazi place different images at different positions.
             if z_index < 0 {
+                // Sixel video streaming dedup: only supersede z<0
+                // placements whose rows OVERLAP with the new image.
+                // This allows consecutive `chafa -f sixel` calls to
+                // stack images vertically while still deduplicating
+                // mpv's repeated same-position frames.
+                let new_row_end = new_row + height_cells as u64;
                 let mut reuse_pos: Option<(u64, usize)> = None;
                 self.image_placements.retain(|p| {
                     if p.overlay || p.z != z_index {
                         return true;
                     }
-                    if reuse_pos.is_none() {
-                        reuse_pos = Some((p.row, p.col));
+                    let p_row_end = p.row + p.height_cells as u64;
+                    let overlaps = new_row < p_row_end && new_row_end > p.row;
+                    if overlaps {
+                        if reuse_pos.is_none() {
+                            reuse_pos = Some((p.row, p.col));
+                        }
+                        superseded.push(p.id);
+                        false
+                    } else {
+                        true
                     }
-                    superseded.push(p.id);
-                    false
                 });
                 if let Some((prev_row, prev_col)) = reuse_pos {
                     new_row = prev_row;
@@ -2949,4 +2961,171 @@ fn row_content_len(cells: &[Cell]) -> usize {
         }
     }
     last_non_empty
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_grid() -> Grid {
+        Grid::with_scrollback(100, 40, 1000)
+    }
+
+    // ---- place_image cursor advancement ----
+
+    #[test]
+    fn place_image_cursor_below_image() {
+        let mut g = make_grid();
+        g.cursor_row = 0;
+        g.cursor_col = 2;
+        g.place_image(1, 640, 480, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        // 480/20 = 24 rows. cursor should land at row 24, not inside image.
+        assert_eq!(g.cursor_row, 24);
+        assert_eq!(g.cursor_col, 0);
+        assert_eq!(g.image_placements.len(), 1);
+        assert_eq!(g.image_placements[0].col, 2);
+    }
+
+    #[test]
+    fn place_image_cursor_scrolls_when_at_bottom() {
+        let mut g = make_grid();
+        g.cursor_row = 30; // near bottom (40 rows)
+        g.cursor_col = 0;
+        // Image 24 rows tall, only 10 rows below cursor → must scroll
+        g.place_image(1, 640, 480, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        // cursor should be at rows-1 = 39, below image
+        assert_eq!(g.cursor_row, 39);
+        // image placement should exist
+        assert_eq!(g.image_placements.len(), 1);
+    }
+
+    #[test]
+    fn place_image_cursor_not_inside_image_exact_fit() {
+        let mut g = make_grid();
+        g.cursor_row = 16;
+        // Image exactly fills remaining rows: 24 rows, rows_below=24
+        g.place_image(1, 640, 480, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        // 16 + 24 = 40 = rows → needs scroll
+        assert_eq!(g.cursor_row, 39);
+    }
+
+    // ---- z<0 dedup (sixel video) ----
+
+    #[test]
+    fn sixel_dedup_reuses_position() {
+        let mut g = make_grid();
+        g.cursor_row = 0;
+        g.cursor_col = 2;
+        // Frame 1: z=-1, placed at (0,2)
+        let sup = g.place_image(1, 960, 720, 10, 20, false, 0, 0, -1, 0, 0, 0, 0, 0, 0);
+        assert!(sup.is_empty());
+        assert_eq!(g.image_placements.len(), 1);
+        assert_eq!(g.image_placements[0].col, 2);
+
+        // Frame 2: cursor drifted to col 56 (mpv status pollution)
+        // but same row → overlaps → dedup fires
+        g.cursor_row = 0;
+        g.cursor_col = 56;
+        let sup = g.place_image(2, 960, 720, 10, 20, false, 0, 0, -1, 0, 0, 0, 0, 0, 0);
+        assert_eq!(sup.len(), 1); // superseded frame 1
+        assert_eq!(sup[0], 1);
+        assert_eq!(g.image_placements.len(), 1);
+        // Should reuse frame 1's position, NOT cursor col 56
+        assert_eq!(g.image_placements[0].col, 2);
+    }
+
+    #[test]
+    fn sixel_consecutive_images_stack_vertically() {
+        let mut g = make_grid();
+        // First chafa -f sixel at row 0
+        g.cursor_row = 0;
+        g.cursor_col = 2;
+        g.place_image(1, 640, 200, 10, 20, false, 0, 0, -1, 0, 0, 0, 0, 0, 0);
+        // 200/20 = 10 rows. cursor now at row 10.
+        assert_eq!(g.cursor_row, 10);
+        assert_eq!(g.image_placements.len(), 1);
+
+        // Second chafa -f sixel at row 10 (below first)
+        g.cursor_col = 2;
+        g.place_image(2, 640, 200, 10, 20, false, 0, 0, -1, 0, 0, 0, 0, 0, 0);
+        // Both images should coexist (different rows, no overlap)
+        assert_eq!(g.image_placements.len(), 2);
+        assert_eq!(g.image_placements[0].id, 1);
+        assert_eq!(g.image_placements[1].id, 2);
+    }
+
+    #[test]
+    fn sixel_dedup_survives_text_writes() {
+        let mut g = make_grid();
+        g.cursor_row = 0;
+        g.cursor_col = 2;
+        g.place_image(1, 960, 720, 10, 20, false, 0, 0, -1, 0, 0, 0, 0, 0, 0);
+        // Simulate text write at row 0 (mpv status)
+        g.cursor_row = 0;
+        g.cursor_col = 0;
+        g.put_char('V');
+        g.put_char(':');
+        // z<0 image should survive text writes
+        assert_eq!(g.image_placements.len(), 1);
+    }
+
+    // ---- z>=0 dedup (kitty/yazi) ----
+
+    #[test]
+    fn kitty_dedup_does_not_reuse_position() {
+        let mut g = make_grid();
+        // Image A at (0, 5)
+        g.cursor_row = 0;
+        g.cursor_col = 5;
+        g.place_image(1, 200, 200, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        assert_eq!(g.image_placements[0].col, 5);
+
+        // Image B at (10, 20) — different position, z=0
+        g.cursor_row = 10;
+        g.cursor_col = 20;
+        g.place_image(2, 200, 200, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        // Should NOT reuse image A's position
+        assert_eq!(g.image_placements.last().unwrap().col, 20);
+    }
+
+    #[test]
+    fn kitty_image_removed_by_text_write() {
+        let mut g = make_grid();
+        g.cursor_row = 5;
+        g.cursor_col = 0;
+        g.place_image(1, 200, 200, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        assert_eq!(g.image_placements.len(), 1);
+        // Write text over the image area (z>=0 should be removed)
+        g.cursor_row = 5;
+        g.cursor_col = 0;
+        g.put_char('X');
+        assert_eq!(g.image_placements.len(), 0);
+    }
+
+    // ---- overlay (C=1) ----
+
+    #[test]
+    fn overlay_not_removed_by_text() {
+        let mut g = make_grid();
+        g.cursor_row = 0;
+        g.cursor_col = 0;
+        g.place_image(1, 200, 200, 10, 20, true, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        // Overlay should survive text writes
+        g.cursor_row = 0;
+        g.cursor_col = 0;
+        g.put_char('X');
+        assert_eq!(g.image_placements.len(), 1);
+    }
+
+    #[test]
+    fn overlay_dedup_same_position() {
+        let mut g = make_grid();
+        g.cursor_row = 0;
+        g.cursor_col = 0;
+        g.place_image(1, 200, 200, 10, 20, true, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        g.place_image(2, 200, 200, 10, 20, true, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        // Second overlay at same position should supersede first
+        assert_eq!(g.image_placements.len(), 1);
+        assert_eq!(g.image_placements[0].id, 2);
+    }
 }

--- a/src/terminal/grid.rs
+++ b/src/terminal/grid.rs
@@ -2516,10 +2516,47 @@ impl Grid {
             // `remove_images_at_cell`, which would discard the placement we
             // just created (observed with `chafa -f sixel` when the prompt
             // rewrite or a newline wrote the first cell after placement).
+            let mut new_row = self.cursor_row as u64 + self.scrollback_total;
+            let mut new_col = self.cursor_col;
+            // `mpv --vo=sixel` resets the cursor to the same cell before each
+            // frame, but its status-display thread may interleave text after
+            // the positioning CUP, advancing the cursor past the intended
+            // column. If an existing same-dimension, same-z placement exists,
+            // reuse its position — the client clearly intended to replace
+            // that exact frame.
+            // Deduplicate for video streaming: `mpv --vo=sixel` sends
+            // identically-sized frames but mpv's status thread may have
+            // shifted the cursor between frames, so their positions differ
+            // slightly. Match by (z, width, height) to catch these.
+            // When a match is found, reuse the FIRST correct position so
+            // subsequent frames don't drift.
+            let mut reuse_pos: Option<(u64, usize)> = None;
+            self.image_placements.retain(|p| {
+                if p.overlay {
+                    return true;
+                }
+                if p.z == z_index
+                    && p.width_cells == width_cells
+                    && p.height_cells == height_cells
+                {
+                    if reuse_pos.is_none() {
+                        reuse_pos = Some((p.row, p.col));
+                    }
+                    superseded.push(p.id);
+                    false
+                } else {
+                    true
+                }
+            });
+            if let Some((prev_row, prev_col)) = reuse_pos {
+                new_row = prev_row;
+                new_col = prev_col;
+            }
+
             let placement = ImagePlacement {
                 id,
-                row: self.cursor_row as u64 + self.scrollback_total,
-                col: self.cursor_col,
+                row: new_row,
+                col: new_col,
                 width_cells,
                 height_cells,
                 pixel_width,

--- a/src/terminal/grid.rs
+++ b/src/terminal/grid.rs
@@ -2402,6 +2402,15 @@ impl Grid {
     /// Place image at current cursor position
     ///
     /// Calculates occupied cell count and moves cursor below image.
+    /// Place an image onto the grid.
+    ///
+    /// Returns the ids of any placements this call superseded. Currently that
+    /// happens for overlay-mode (`C=1`) placements that are fully covered by
+    /// the new one at the same z-index — `mpv --vo=kitty` streams identically
+    /// sized frames at the same cell position, so without this dedupe each
+    /// frame would leak a placement and its backing image, overwhelming the
+    /// registry and stalling PTY reads within seconds. Callers should drop
+    /// the returned ids from the image registry to free their texture data.
     pub fn place_image(
         &mut self,
         id: u32,
@@ -2419,10 +2428,10 @@ impl Grid {
         src_y: u32,
         src_w: u32,
         src_h: u32,
-    ) {
+    ) -> Vec<u32> {
         if cell_width == 0 || cell_height == 0 {
             log::warn!("place_image: cell size not set, skipping placement");
-            return;
+            return Vec::new();
         }
 
         // Use explicit c=/r= if provided, otherwise calculate from pixel size (round up)
@@ -2447,14 +2456,38 @@ impl Grid {
             if do_not_move_cursor { 1 } else { 0 }
         );
 
+        let mut superseded: Vec<u32> = Vec::new();
+
         if do_not_move_cursor {
             // C=1: place image at cursor position, do not move cursor
             // Overlay mode: text writes don't remove this image
             // Overlay uses screen-relative row (doesn't scroll with text)
+            let new_row = self.cursor_row as u64;
+            let new_col = self.cursor_col;
+            let new_row_end = new_row + height_cells as u64;
+            let new_col_end = new_col + width_cells;
+            self.image_placements.retain(|p| {
+                if !p.overlay || p.z != z_index {
+                    return true;
+                }
+                let p_row_end = p.row + p.height_cells as u64;
+                let p_col_end = p.col + p.width_cells;
+                let fully_covered = p.row >= new_row
+                    && p_row_end <= new_row_end
+                    && p.col >= new_col
+                    && p_col_end <= new_col_end;
+                if fully_covered {
+                    superseded.push(p.id);
+                    false
+                } else {
+                    true
+                }
+            });
+
             let placement = ImagePlacement {
                 id,
-                row: self.cursor_row as u64,
-                col: self.cursor_col,
+                row: new_row,
+                col: new_col,
                 width_cells,
                 height_cells,
                 pixel_width,
@@ -2476,75 +2509,55 @@ impl Grid {
             };
             self.image_placements.push(placement);
         } else {
-            // Default: place image and move cursor below it
-            // For large images that exceed screen, scroll first, then place
-            let rows_below = self.rows - self.cursor_row;
-            if height_cells > rows_below {
-                // Need to scroll to make room; scroll before placing
-                // so the placement doesn't get deleted by scroll_up
-                let scroll_needed = height_cells - rows_below;
+            // Place the image at the current cursor position (absolute row =
+            // screen row + scrollback), then advance the cursor onto the row
+            // one past the image. Landing the cursor inside the image area
+            // is destructive: the next `put_char` invokes
+            // `remove_images_at_cell`, which would discard the placement we
+            // just created (observed with `chafa -f sixel` when the prompt
+            // rewrite or a newline wrote the first cell after placement).
+            let placement = ImagePlacement {
+                id,
+                row: self.cursor_row as u64 + self.scrollback_total,
+                col: self.cursor_col,
+                width_cells,
+                height_cells,
+                pixel_width,
+                pixel_height,
+                overlay: false,
+                z: z_index,
+                offset_x,
+                offset_y,
+                src_x,
+                src_y,
+                src_w,
+                src_h,
+                is_virtual: false,
+                placement_id: 0,
+                parent_id: 0,
+                parent_placement_id: 0,
+                rel_h: 0,
+                rel_v: 0,
+            };
+            self.image_placements.push(placement);
+
+            let target_cursor_row = self.cursor_row + height_cells;
+            if target_cursor_row >= self.rows {
+                // Scroll so the row immediately below the image exists on
+                // screen. Placements use absolute coordinates, so scrolling
+                // after the push does not shift the image we just added.
+                let scroll_needed = target_cursor_row + 1 - self.rows;
                 for _ in 0..scroll_needed {
                     self.scroll_up(1);
                 }
-                // Image starts at adjusted position
-                let start_row = self.rows.saturating_sub(height_cells);
-                let placement = ImagePlacement {
-                    id,
-                    row: start_row as u64 + self.scrollback_total,
-                    col: self.cursor_col,
-                    width_cells,
-                    height_cells,
-                    pixel_width,
-                    pixel_height,
-                    overlay: false,
-                    z: z_index,
-                    offset_x,
-                    offset_y,
-                    src_x,
-                    src_y,
-                    src_w,
-                    src_h,
-                    is_virtual: false,
-                    placement_id: 0,
-                    parent_id: 0,
-                    parent_placement_id: 0,
-                    rel_h: 0,
-                    rel_v: 0,
-                };
-                self.image_placements.push(placement);
                 self.cursor_row = self.rows - 1;
             } else {
-                let placement = ImagePlacement {
-                    id,
-                    row: self.cursor_row as u64 + self.scrollback_total,
-                    col: self.cursor_col,
-                    width_cells,
-                    height_cells,
-                    pixel_width,
-                    pixel_height,
-                    overlay: false,
-                    z: z_index,
-                    offset_x,
-                    offset_y,
-                    src_x,
-                    src_y,
-                    src_w,
-                    src_h,
-                    is_virtual: false,
-                    placement_id: 0,
-                    parent_id: 0,
-                    parent_placement_id: 0,
-                    rel_h: 0,
-                    rel_v: 0,
-                };
-                self.image_placements.push(placement);
-                self.cursor_row += height_cells;
-                if self.cursor_row >= self.rows {
-                    self.cursor_row = self.rows - 1;
-                }
+                self.cursor_row = target_cursor_row;
             }
             self.cursor_col = 0;
         }
+
+        superseded
     }
 
     /// Delete image placements that scrolled out of screen

--- a/src/terminal/grid.rs
+++ b/src/terminal/grid.rs
@@ -3040,14 +3040,14 @@ mod tests {
         // First chafa -f sixel at row 0
         g.cursor_row = 0;
         g.cursor_col = 2;
-        g.place_image(1, 640, 200, 10, 20, false, 0, 0, -1, 0, 0, 0, 0, 0, 0);
+        g.place_image(1, 640, 200, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         // 200/20 = 10 rows. cursor now at row 10.
         assert_eq!(g.cursor_row, 10);
         assert_eq!(g.image_placements.len(), 1);
 
         // Second chafa -f sixel at row 10 (below first)
         g.cursor_col = 2;
-        g.place_image(2, 640, 200, 10, 20, false, 0, 0, -1, 0, 0, 0, 0, 0, 0);
+        g.place_image(2, 640, 200, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         // Both images should coexist (different rows, no overlap)
         assert_eq!(g.image_placements.len(), 2);
         assert_eq!(g.image_placements[0].id, 1);
@@ -3055,18 +3055,16 @@ mod tests {
     }
 
     #[test]
-    fn sixel_dedup_survives_text_writes() {
+    fn sixel_removed_by_text_writes() {
         let mut g = make_grid();
         g.cursor_row = 0;
         g.cursor_col = 2;
-        g.place_image(1, 960, 720, 10, 20, false, 0, 0, -1, 0, 0, 0, 0, 0, 0);
-        // Simulate text write at row 0 (mpv status)
+        g.place_image(1, 960, 720, 10, 20, false, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         g.cursor_row = 0;
-        g.cursor_col = 0;
-        g.put_char('V');
-        g.put_char(':');
-        // z<0 image should survive text writes
-        assert_eq!(g.image_placements.len(), 1);
+        g.cursor_col = 2;
+        g.put_char('X');
+        // z=0 image removed by text write (yazi preview clear)
+        assert_eq!(g.image_placements.len(), 0);
     }
 
     // ---- z>=0 dedup (kitty/yazi) ----

--- a/src/terminal/kitty.rs
+++ b/src/terminal/kitty.rs
@@ -317,7 +317,9 @@ pub struct KittyParams {
 
 /// Kitty decoder
 pub struct KittyDecoder {
-    /// Accumulated raw base64 payload (decoded in finish())
+    /// Accumulated decoded payload bytes.
+    /// Each chunk's base64 payload is a self-contained unit (may end with `=`
+    /// padding), so we decode per-chunk and append the resulting bytes here.
     payload_buffer: Vec<u8>,
     /// Current parameters
     params: KittyParams,
@@ -369,13 +371,22 @@ impl KittyDecoder {
             }
         }
 
-        // Accumulate raw base64 payload (decoded later in finish())
-        // Must accumulate raw text to avoid corruption at non-4-char chunk boundaries
+        // Decode each chunk's base64 payload independently and append the
+        // resulting bytes. Chunks are self-contained base64 units per the Kitty
+        // protocol — e.g. chafa ends every chunk with `=` padding — so we must
+        // NOT concatenate raw base64 across chunks (that would drop the
+        // leftover bits of each chunk's final group into the next chunk's
+        // bitstream and shift the decoded output).
         if !payload.is_empty() {
-            let new_len = self.payload_buffer.len() + payload.len();
-            // Approximate decoded size check (base64 is ~4/3 of binary)
-            if new_len * 3 / 4 <= MAX_IMAGE_DATA_SIZE {
-                self.payload_buffer.extend_from_slice(payload.as_bytes());
+            let decoded = match base64_decode(payload.as_bytes()) {
+                Some(d) => d,
+                None => {
+                    warn!("Kitty: invalid base64 in chunk");
+                    return (true, None);
+                }
+            };
+            if self.payload_buffer.len() + decoded.len() <= MAX_IMAGE_DATA_SIZE {
+                self.payload_buffer.extend_from_slice(&decoded);
             } else {
                 warn!(
                     "Kitty: image data exceeds {}MB limit, truncating",
@@ -546,19 +557,10 @@ impl KittyDecoder {
         let params = self.params;
         let id = if params.id != 0 { params.id } else { next_id };
 
-        // Decode accumulated base64 payload
-        let raw_data = if self.payload_buffer.is_empty() {
-            Vec::new()
-        } else {
-            let decoded = base64_decode(&self.payload_buffer)
-                .ok_or_else(|| "invalid base64 data".to_string())?;
-            info!(
-                "Kitty: base64 decoded {} chars -> {} bytes",
-                self.payload_buffer.len(),
-                decoded.len()
-            );
-            decoded
-        };
+        // payload_buffer already contains decoded bytes (chunks are decoded
+        // on arrival in process()).
+        let raw_data = self.payload_buffer;
+        info!("Kitty: total decoded payload = {} bytes", raw_data.len());
 
         // Handle non-data actions first
         match params.action {
@@ -1003,5 +1005,84 @@ pub fn make_response(id: u32, ok: bool, message: &str) -> Vec<u8> {
         format!("\x1b_Gi={};OK\x1b\\", id).into_bytes()
     } else {
         format!("\x1b_Gi={};{}\x1b\\", id, message).into_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b64_encode(data: &[u8]) -> String {
+        const TBL: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+        let mut i = 0;
+        while i + 3 <= data.len() {
+            let n = ((data[i] as u32) << 16) | ((data[i + 1] as u32) << 8) | data[i + 2] as u32;
+            out.push(TBL[((n >> 18) & 0x3f) as usize] as char);
+            out.push(TBL[((n >> 12) & 0x3f) as usize] as char);
+            out.push(TBL[((n >> 6) & 0x3f) as usize] as char);
+            out.push(TBL[(n & 0x3f) as usize] as char);
+            i += 3;
+        }
+        let rem = data.len() - i;
+        if rem == 1 {
+            let n = (data[i] as u32) << 16;
+            out.push(TBL[((n >> 18) & 0x3f) as usize] as char);
+            out.push(TBL[((n >> 12) & 0x3f) as usize] as char);
+            out.push_str("==");
+        } else if rem == 2 {
+            let n = ((data[i] as u32) << 16) | ((data[i + 1] as u32) << 8);
+            out.push(TBL[((n >> 18) & 0x3f) as usize] as char);
+            out.push(TBL[((n >> 12) & 0x3f) as usize] as char);
+            out.push(TBL[((n >> 6) & 0x3f) as usize] as char);
+            out.push('=');
+        }
+        out
+    }
+
+    /// Reproduces the chafa-style chunked Kitty transmission where each chunk
+    /// is a self-contained base64 unit ending in `=` padding. The bug: bcon
+    /// used to concatenate raw base64 across chunks and skip `=` during decode,
+    /// leaking 2 leftover bits from each chunk's final group into the next
+    /// chunk and producing `num_chunks * 2 / 8` extra bytes in the output.
+    #[test]
+    fn chunked_base64_with_per_chunk_padding_decodes_exact() {
+        let w = 32u32;
+        let h = 16u32;
+        let pixel_count = (w * h) as usize;
+        // Distinct byte pattern so off-by-one errors become visible.
+        let rgba: Vec<u8> = (0..pixel_count * 4).map(|i| (i & 0xff) as u8).collect();
+        assert_eq!(rgba.len(), 32 * 16 * 4);
+
+        // Chunk size chosen so each chunk encodes to a base64 unit ending in
+        // `=` padding (512 bytes → 684 chars with one trailing `=`, matching
+        // chafa's actual chunking).
+        let chunk_bytes = 512;
+        let chunks: Vec<&[u8]> = rgba.chunks(chunk_bytes).collect();
+        let num_chunks = chunks.len();
+        assert!(num_chunks >= 2);
+
+        let mut decoder = KittyDecoder::new();
+        // First APC: metadata only, no payload, m=1 (chafa-style).
+        let first = format!("a=T,f=32,s={},v={},m=1", w, h);
+        decoder.process(first.as_bytes());
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            let more = if i + 1 < num_chunks { 1 } else { 0 };
+            let body = format!("m={};{}", more, b64_encode(chunk));
+            decoder.process(body.as_bytes());
+        }
+
+        let result = decoder.finish(1, false).expect("decode");
+        match result {
+            KittyDecodeResult::Image(img) => {
+                assert_eq!(img.width, w);
+                assert_eq!(img.height, h);
+                assert_eq!(img.data.len(), rgba.len());
+                assert_eq!(img.data, rgba);
+            }
+            _ => panic!("expected Image result"),
+        }
     }
 }

--- a/src/terminal/kitty.rs
+++ b/src/terminal/kitty.rs
@@ -560,7 +560,7 @@ impl KittyDecoder {
         // payload_buffer already contains decoded bytes (chunks are decoded
         // on arrival in process()).
         let raw_data = self.payload_buffer;
-        info!("Kitty: total decoded payload = {} bytes", raw_data.len());
+        trace!("Kitty: total decoded payload = {} bytes", raw_data.len());
 
         // Handle non-data actions first
         match params.action {
@@ -629,7 +629,7 @@ impl KittyDecoder {
         // For image actions (Transmit, TransmitAndDisplay, Query)
         let (width, height, rgba) = decode_image_data(&params, data)?;
 
-        info!("Kitty: decoded image {}x{} (id={})", width, height, id);
+        trace!("Kitty: decoded image {}x{} (id={})", width, height, id);
 
         Ok(KittyDecodeResult::Image(KittyImage {
             id,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -904,11 +904,48 @@ impl Terminal {
         }
     }
 
-    /// Slow path: byte-by-byte processing with APC state machine
+    /// Slow path: byte-by-byte processing with APC/DCS state machine.
+    ///
+    /// When in DcsData state (sixel streaming), uses a tight inner loop
+    /// that scans for ESC/0x9C and feeds everything else to the decoder
+    /// in bulk — avoiding per-byte match + Option check overhead.
     fn process_pty_output_slow(&mut self, n: usize) {
         self.pty_response.clear();
-        for i in 0..n {
+        let mut i = 0;
+        while i < n {
+            // Fast inner loop for sixel data: skip the outer match entirely
+            // and scan for ESC (DCS terminator) in bulk.
+            if matches!(self.apc_state, ApcState::DcsData) {
+                if let Some(DcsHandler::Sixel(ref mut dec)) = self.dcs_handler {
+                    while i < n {
+                        let byte = self.read_buf[i];
+                        if byte == 0x1B {
+                            self.apc_state = ApcState::DcsEscape;
+                            i += 1;
+                            break;
+                        } else if byte == 0x9C {
+                            i += 1;
+                            // Need to drop the mutable borrow before calling finish
+                            break;
+                        }
+                        dec.push(byte);
+                        i += 1;
+                    }
+                    // Handle 0x9C (C1 ST) that broke out of the inner loop
+                    if i > 0 && self.read_buf[i - 1] == 0x9C
+                        && matches!(self.apc_state, ApcState::DcsData)
+                    {
+                        self.finish_dcs_sixel();
+                        self.apc_state = ApcState::Normal;
+                    }
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+
             let byte = self.read_buf[i];
+            i += 1;
 
             match self.apc_state {
                 ApcState::Normal => {
@@ -923,8 +960,6 @@ impl Terminal {
                         self.apc_state = ApcState::InApc;
                         self.apc_buffer.clear();
                     } else if byte == b'P' {
-                        // DCS start — handle sixel ourselves to avoid vte
-                        // state bugs under streaming sixel load.
                         self.apc_state = ApcState::DcsParams;
                         self.apc_buffer.clear();
                     } else {
@@ -958,19 +993,14 @@ impl Terminal {
                     }
                 }
                 ApcState::DcsParams => {
-                    // Collect bytes until the final char (0x40-0x7E).
                     if (0x40..=0x7E).contains(&byte) {
                         if byte == b'q' {
-                            // Sixel DCS — start collecting data directly
                             trace!("Sixel DCS started (direct)");
                             self.dcs_handler = Some(DcsHandler::Sixel(
                                 SixelDecoder::new(),
                             ));
                             self.apc_state = ApcState::DcsData;
                         } else {
-                            // Non-sixel DCS (DECRQSS, XTGETTCAP, etc.) —
-                            // replay ESC P <params> <final> to vte for
-                            // standard handling and return to Normal.
                             self.process_byte_with_vte(0x1B);
                             self.process_byte_with_vte(b'P');
                             for &b in &self.apc_buffer.clone() {
@@ -979,40 +1009,23 @@ impl Terminal {
                             self.process_byte_with_vte(byte);
                             self.apc_state = ApcState::Normal;
                         }
-                    } else {
-                        // DCS parameter/intermediate byte — buffer it
-                        if self.apc_buffer.len() < 64 {
-                            self.apc_buffer.push(byte);
-                        }
+                    } else if self.apc_buffer.len() < 64 {
+                        self.apc_buffer.push(byte);
                     }
                 }
                 ApcState::DcsData => {
-                    // Sixel data bytes — feed directly to decoder.
-                    // This is the hot path; no vte, no Performer overhead.
-                    if byte == 0x1B {
-                        self.apc_state = ApcState::DcsEscape;
-                    } else if byte == 0x9C {
-                        // C1 ST — end of DCS
-                        self.finish_dcs_sixel();
-                        self.apc_state = ApcState::Normal;
-                    } else if let Some(DcsHandler::Sixel(ref mut dec)) = self.dcs_handler {
-                        dec.push(byte);
-                    }
+                    // Fallback (shouldn't reach here due to fast path above)
+                    unreachable!("DcsData handled by fast inner loop");
                 }
                 ApcState::DcsEscape => {
                     if byte == b'\\' {
-                        // ESC \ = ST — end of DCS
                         self.finish_dcs_sixel();
                         self.apc_state = ApcState::Normal;
                     } else if byte == 0x1B {
-                        // Double ESC — first was data, second might be ST
                         if let Some(DcsHandler::Sixel(ref mut dec)) = self.dcs_handler {
                             dec.push(0x1B);
                         }
-                        // stay in DcsEscape
                     } else {
-                        // False alarm — ESC was part of data (shouldn't
-                        // happen in valid sixel, but be safe)
                         if let Some(DcsHandler::Sixel(ref mut dec)) = self.dcs_handler {
                             dec.push(0x1B);
                             dec.push(byte);

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1101,7 +1101,7 @@ impl Terminal {
                         self.cell_height,
                         false,
                         0, 0,
-                        -1, // z < 0: sixel survives text overwrites
+                        0, // z=0: removed by text writes (yazi preview clear)
                         0, 0,
                         0, 0, 0, 0,
                     );
@@ -1163,14 +1163,16 @@ impl Terminal {
                 self.images.next_id
             };
 
-            log::info!(
-                "Kitty finish_decode: action={:?}, id={}, quiet={}, C={}, size={}x{}",
+            log::trace!(
+                "Kitty finish_decode: action={:?}, id={}, quiet={}, C={}, U={}, size={}x{}, placements={}",
                 action,
                 id,
                 quiet,
                 if no_cursor_move { 1 } else { 0 },
+                if params.unicode_placement { 1 } else { 0 },
                 params.width,
-                params.height
+                params.height,
+                self.grid.image_placements.len()
             );
 
             match action {
@@ -1271,7 +1273,6 @@ impl Terminal {
                         }
                         _ => {}
                     }
-                    // Trigger redraw after image deletion
                     self.grid.mark_all_dirty();
                 }
                 KittyAction::Display => {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -83,6 +83,18 @@ fn has_esc_underscore(buf: &[u8]) -> bool {
     false
 }
 
+fn has_esc_p(buf: &[u8]) -> bool {
+    if buf.len() < 2 {
+        return false;
+    }
+    for i in 0..buf.len() - 1 {
+        if buf[i] == 0x1B && buf[i + 1] == b'P' {
+            return true;
+        }
+    }
+    false
+}
+
 /// Copy mode state
 pub struct CopyModeState {
     /// Copy mode cursor row (display coordinates)
@@ -540,6 +552,14 @@ enum ApcState {
     InApc,
     /// Waiting for APC termination (ESC detected)
     ApcEscape,
+    /// ESC P detected, collecting DCS params until final char (0x40-0x7E)
+    DcsParams,
+    /// Inside DCS sixel data (final char was 'q'). Bytes go directly to
+    /// the SixelDecoder without touching vte, avoiding vte state bugs that
+    /// cause sixel data to leak as printed text under streaming load.
+    DcsData,
+    /// ESC detected inside DCS data (potential ST = ESC \)
+    DcsEscape,
 }
 
 /// Terminal emulator
@@ -820,17 +840,21 @@ impl Terminal {
 
         trace!("PTY read: {} bytes", n);
 
-        // Fast path: if already in APC state or buffer contains ESC _, use slow path
-        // This handles the rare APC (Kitty graphics) case
-        // Use manual loop instead of windows(2).any() to avoid iterator overhead
-        // Include ApcState::Escape to handle ESC at buffer boundary (ESC in prev buffer, _ in this one)
-        let has_apc = matches!(
+        // Slow path is needed when we're inside (or about to enter) an APC
+        // or DCS sequence that bcon handles directly (bypassing vte).
+        let needs_slow = matches!(
             self.apc_state,
-            ApcState::Escape | ApcState::InApc | ApcState::ApcEscape
-        ) || has_esc_underscore(&self.read_buf[..n]);
+            ApcState::Escape
+                | ApcState::InApc
+                | ApcState::ApcEscape
+                | ApcState::DcsParams
+                | ApcState::DcsData
+                | ApcState::DcsEscape
+        ) || has_esc_underscore(&self.read_buf[..n])
+            || has_esc_p(&self.read_buf[..n]);
 
-        if has_apc {
-            // Slow path: byte-by-byte for APC handling
+        if needs_slow {
+            // Slow path: byte-by-byte for APC/DCS handling
             self.process_pty_output_slow(n);
         } else {
             // Fast path: single Performer for all bytes
@@ -898,6 +922,11 @@ impl Terminal {
                     if byte == b'_' {
                         self.apc_state = ApcState::InApc;
                         self.apc_buffer.clear();
+                    } else if byte == b'P' {
+                        // DCS start — handle sixel ourselves to avoid vte
+                        // state bugs under streaming sixel load.
+                        self.apc_state = ApcState::DcsParams;
+                        self.apc_buffer.clear();
                     } else {
                         self.apc_state = ApcState::Normal;
                         self.process_byte_with_vte(0x1B);
@@ -926,6 +955,69 @@ impl Terminal {
                             self.apc_buffer.push(byte);
                             self.apc_state = ApcState::InApc;
                         }
+                    }
+                }
+                ApcState::DcsParams => {
+                    // Collect bytes until the final char (0x40-0x7E).
+                    if (0x40..=0x7E).contains(&byte) {
+                        if byte == b'q' {
+                            // Sixel DCS — start collecting data directly
+                            info!("Sixel DCS started (direct)");
+                            self.dcs_handler = Some(DcsHandler::Sixel(
+                                SixelDecoder::new(),
+                            ));
+                            self.apc_state = ApcState::DcsData;
+                        } else {
+                            // Non-sixel DCS (DECRQSS, XTGETTCAP, etc.) —
+                            // replay ESC P <params> <final> to vte for
+                            // standard handling and return to Normal.
+                            self.process_byte_with_vte(0x1B);
+                            self.process_byte_with_vte(b'P');
+                            for &b in &self.apc_buffer.clone() {
+                                self.process_byte_with_vte(b);
+                            }
+                            self.process_byte_with_vte(byte);
+                            self.apc_state = ApcState::Normal;
+                        }
+                    } else {
+                        // DCS parameter/intermediate byte — buffer it
+                        if self.apc_buffer.len() < 64 {
+                            self.apc_buffer.push(byte);
+                        }
+                    }
+                }
+                ApcState::DcsData => {
+                    // Sixel data bytes — feed directly to decoder.
+                    // This is the hot path; no vte, no Performer overhead.
+                    if byte == 0x1B {
+                        self.apc_state = ApcState::DcsEscape;
+                    } else if byte == 0x9C {
+                        // C1 ST — end of DCS
+                        self.finish_dcs_sixel();
+                        self.apc_state = ApcState::Normal;
+                    } else if let Some(DcsHandler::Sixel(ref mut dec)) = self.dcs_handler {
+                        dec.push(byte);
+                    }
+                }
+                ApcState::DcsEscape => {
+                    if byte == b'\\' {
+                        // ESC \ = ST — end of DCS
+                        self.finish_dcs_sixel();
+                        self.apc_state = ApcState::Normal;
+                    } else if byte == 0x1B {
+                        // Double ESC — first was data, second might be ST
+                        if let Some(DcsHandler::Sixel(ref mut dec)) = self.dcs_handler {
+                            dec.push(0x1B);
+                        }
+                        // stay in DcsEscape
+                    } else {
+                        // False alarm — ESC was part of data (shouldn't
+                        // happen in valid sixel, but be safe)
+                        if let Some(DcsHandler::Sixel(ref mut dec)) = self.dcs_handler {
+                            dec.push(0x1B);
+                            dec.push(byte);
+                        }
+                        self.apc_state = ApcState::DcsData;
                     }
                 }
             }
@@ -958,6 +1050,54 @@ impl Terminal {
         if !self.pty_response.is_empty() {
             log::trace!("PTY response: {} bytes", self.pty_response.len());
             self.write_response(&self.pty_response);
+        }
+    }
+
+    /// Finish a DCS sixel sequence that was handled directly (bypassing vte).
+    /// Mirrors the unhook logic in parser.rs but operates on Terminal fields.
+    fn finish_dcs_sixel(&mut self) {
+        // SixelDecoder is already imported at module level (use sixel::SixelDecoder)
+        if let Some(DcsHandler::Sixel(decoder)) = self.dcs_handler.take() {
+            let id = self.images.next_id;
+            if let Some(sixel_img) = decoder.finish(id) {
+                info!(
+                    "Sixel image decode complete: {}x{} (id={})",
+                    sixel_img.width, sixel_img.height, sixel_img.id
+                );
+                let term_img = TerminalImage {
+                    id: sixel_img.id,
+                    width: sixel_img.width,
+                    height: sixel_img.height,
+                    data: sixel_img.data,
+                    frames: Vec::new(),
+                    animation_state: AnimationState::Stopped,
+                    current_frame: 0,
+                    loop_count: 0,
+                    current_loop: 0,
+                    root_gap: 0,
+                    last_frame_time: std::time::Instant::now(),
+                };
+                let img_id = self.images.insert(term_img);
+                self.dirty_image_ids.push(img_id);
+                if let Some(image) = self.images.get(img_id) {
+                    let superseded = self.grid.place_image(
+                        img_id,
+                        image.width,
+                        image.height,
+                        self.cell_width,
+                        self.cell_height,
+                        false,
+                        0, 0,
+                        -1, // z < 0: sixel survives text overwrites
+                        0, 0,
+                        0, 0, 0, 0,
+                    );
+                    for old_id in superseded {
+                        self.images.remove(old_id);
+                        self.dirty_image_ids.push(old_id);
+                    }
+                }
+            }
         }
     }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -849,6 +849,7 @@ impl Terminal {
             &mut self.clipboard,
             &mut self.dcs_handler,
             &mut self.images,
+            &mut self.dirty_image_ids,
             self.cell_width,
             self.cell_height,
             &mut self.current_directory,
@@ -940,6 +941,7 @@ impl Terminal {
             &mut self.clipboard,
             &mut self.dcs_handler,
             &mut self.images,
+            &mut self.dirty_image_ids,
             self.cell_width,
             self.cell_height,
             &mut self.current_directory,
@@ -990,7 +992,7 @@ impl Terminal {
 
     /// Finish Kitty decode processing
     fn finish_kitty_decode(&mut self) {
-        use kitty::{make_response, KittyAction};
+        use kitty::KittyAction;
 
         if let Some(decoder) = self.kitty_decoder.take() {
             let params = decoder.params();
@@ -999,6 +1001,9 @@ impl Terminal {
             let no_cursor_move = params.do_not_move_cursor;
             let display_cols = params.cols;
             let display_rows = params.rows;
+            // Per Kitty graphics spec: terminals must not emit responses
+            // unless the client identified the command with i= or I=.
+            let client_requested_response = params.id != 0 || params.number != 0;
             let id = if params.id != 0 {
                 params.id
             } else {
@@ -1198,7 +1203,11 @@ impl Terminal {
                             }
                         }
                     } else if let Some(image) = self.images.get(id) {
-                        self.grid.place_image(
+                        // Re-display of an existing image (a=p). Don't drop
+                        // superseded ids here — the image may still be owned
+                        // by other live placements; let registry LRU handle
+                        // reclamation.
+                        let _ = self.grid.place_image(
                             id,
                             image.width,
                             image.height,
@@ -1218,11 +1227,15 @@ impl Terminal {
                     }
                 }
                 KittyAction::Query => {
-                    // a=q is for protocol support detection - always return OK
-                    if quiet < 2 {
-                        let resp = make_response(id, true, "");
-                        self.write_response(&resp);
-                    }
+                    // a=q is for protocol support detection. Query responses
+                    // are still gated on the client identifying the command.
+                    self.maybe_send_kitty_response(
+                        client_requested_response,
+                        quiet,
+                        id,
+                        true,
+                        "",
+                    );
                 }
                 // Actions that produce decode results
                 KittyAction::Transmit
@@ -1232,14 +1245,22 @@ impl Terminal {
                 | KittyAction::Animation => {
                     match decoder.finish(self.images.next_id, self.allow_kitty_remote) {
                         Ok(result) => {
-                            self.handle_kitty_result(result, action, quiet);
+                            self.handle_kitty_result(
+                                result,
+                                action,
+                                quiet,
+                                client_requested_response,
+                            );
                         }
                         Err(e) => {
                             log::warn!("Kitty decode error: {}", e);
-                            if quiet < 2 {
-                                let resp = make_response(id, false, &e);
-                                self.write_response(&resp);
-                            }
+                            self.maybe_send_kitty_response(
+                                client_requested_response,
+                                quiet,
+                                id,
+                                false,
+                                &e,
+                            );
                         }
                     }
                 }
@@ -1247,14 +1268,21 @@ impl Terminal {
         }
     }
 
-    /// Handle Kitty decode result
+    /// Handle Kitty decode result.
+    ///
+    /// `client_requested_response` reflects whether the client identified the
+    /// image with `i=` or `I=`. Per the Kitty graphics protocol, terminals
+    /// must not emit responses for commands without one of those keys —
+    /// chafa's transmissions omit both, so honoring this is what stops the
+    /// "OK" reply from leaking into the shell's input as visible text.
     fn handle_kitty_result(
         &mut self,
         result: kitty::KittyDecodeResult,
         action: kitty::KittyAction,
         quiet: u8,
+        client_requested_response: bool,
     ) {
-        use kitty::{make_response, KittyAction, KittyDecodeResult};
+        use kitty::{KittyAction, KittyDecodeResult};
 
         match result {
             KittyDecodeResult::Image(kitty_img) => {
@@ -1298,7 +1326,7 @@ impl Terminal {
                 self.images.insert(term_img);
 
                 if action == KittyAction::TransmitAndDisplay {
-                    self.grid.place_image(
+                    let superseded = self.grid.place_image(
                         img_id,
                         width,
                         height,
@@ -1312,17 +1340,22 @@ impl Terminal {
                         kitty_img.src_x, kitty_img.src_y,
                         kitty_img.src_w, kitty_img.src_h,
                     );
+                    // Drop images that were fully covered by this placement so
+                    // their memory and cached GPU textures are reclaimed every
+                    // frame (critical under `mpv --vo=kitty`-style streaming).
+                    for old_id in superseded {
+                        self.images.remove(old_id);
+                        self.dirty_image_ids.push(old_id);
+                    }
                 }
 
-                if quiet < 2 {
-                    let resp = make_response(img_id, true, "");
-                    log::info!(
-                        "Kitty graphics: sending OK response for id={} ({} bytes)",
-                        img_id,
-                        resp.len()
-                    );
-                    self.write_response(&resp);
-                }
+                self.maybe_send_kitty_response(
+                    client_requested_response,
+                    quiet,
+                    img_id,
+                    true,
+                    "",
+                );
             }
             KittyDecodeResult::Frame(frame_data) => {
                 info!(
@@ -1386,17 +1419,22 @@ impl Terminal {
                     // Recalculate tracked memory after frame mutation
                     self.images.enforce_limits();
 
-                    if quiet < 2 {
-                        let resp = make_response(frame_data.image_id, true, "");
-                        self.write_response(&resp);
-                    }
+                    self.maybe_send_kitty_response(
+                        client_requested_response,
+                        quiet,
+                        frame_data.image_id,
+                        true,
+                        "",
+                    );
                 } else {
                     log::warn!("Kitty frame: image {} not found", frame_data.image_id);
-                    if quiet < 2 {
-                        let resp =
-                            make_response(frame_data.image_id, false, "ENOENT:image not found");
-                        self.write_response(&resp);
-                    }
+                    self.maybe_send_kitty_response(
+                        client_requested_response,
+                        quiet,
+                        frame_data.image_id,
+                        false,
+                        "ENOENT:image not found",
+                    );
                 }
             }
             KittyDecodeResult::Compose(cmd) => {
@@ -1420,19 +1458,25 @@ impl Terminal {
                         cmd.compose_mode,
                     );
 
-                    if quiet < 2 {
-                        let resp = if result.is_ok() {
-                            make_response(cmd.image_id, true, "")
-                        } else {
-                            make_response(cmd.image_id, false, &result.unwrap_err())
-                        };
-                        self.write_response(&resp);
-                    }
+                    let (ok, msg) = match &result {
+                        Ok(()) => (true, String::new()),
+                        Err(e) => (false, e.clone()),
+                    };
+                    self.maybe_send_kitty_response(
+                        client_requested_response,
+                        quiet,
+                        cmd.image_id,
+                        ok,
+                        &msg,
+                    );
                 } else {
-                    if quiet < 2 {
-                        let resp = make_response(cmd.image_id, false, "ENOENT:image not found");
-                        self.write_response(&resp);
-                    }
+                    self.maybe_send_kitty_response(
+                        client_requested_response,
+                        quiet,
+                        cmd.image_id,
+                        false,
+                        "ENOENT:image not found",
+                    );
                 }
             }
             KittyDecodeResult::Animation(cmd) => {
@@ -1474,15 +1518,21 @@ impl Terminal {
                         }
                     }
 
-                    if quiet < 2 {
-                        let resp = make_response(cmd.image_id, true, "");
-                        self.write_response(&resp);
-                    }
+                    self.maybe_send_kitty_response(
+                        client_requested_response,
+                        quiet,
+                        cmd.image_id,
+                        true,
+                        "",
+                    );
                 } else {
-                    if quiet < 2 {
-                        let resp = make_response(cmd.image_id, false, "ENOENT:image not found");
-                        self.write_response(&resp);
-                    }
+                    self.maybe_send_kitty_response(
+                        client_requested_response,
+                        quiet,
+                        cmd.image_id,
+                        false,
+                        "ENOENT:image not found",
+                    );
                 }
             }
         }
@@ -1599,6 +1649,24 @@ impl Terminal {
         if let Err(e) = self.pty.write_all(data) {
             log::warn!("PTY response write failed: {}", e);
         }
+    }
+
+    /// Send a Kitty graphics response only when the spec permits it:
+    /// the client must have identified the command with `i=` or `I=`
+    /// (`client_requested_response`), and `q=2` always suppresses output.
+    fn maybe_send_kitty_response(
+        &self,
+        client_requested_response: bool,
+        quiet: u8,
+        id: u32,
+        ok: bool,
+        message: &str,
+    ) {
+        if !client_requested_response || quiet >= 2 {
+            return;
+        }
+        let resp = kitty::make_response(id, ok, message);
+        self.write_response(&resp);
     }
 
     /// Write data to PTY (for keyboard input forwarding)
@@ -2520,6 +2588,7 @@ impl Terminal {
             &mut self.clipboard,
             &mut self.dcs_handler,
             &mut self.images,
+            &mut self.dirty_image_ids,
             self.cell_width,
             self.cell_height,
             &mut self.current_directory,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -23,7 +23,7 @@ use pty::Pty;
 use sixel::SixelDecoder;
 
 /// Read buffer size
-const READ_BUF_SIZE: usize = 4096;
+const READ_BUF_SIZE: usize = 262144; // 256KB — one sixel frame fits in ~2 reads
 
 /// Maximum notification history entries
 const MAX_NOTIFICATIONS: usize = 100;

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -962,7 +962,7 @@ impl Terminal {
                     if (0x40..=0x7E).contains(&byte) {
                         if byte == b'q' {
                             // Sixel DCS — start collecting data directly
-                            info!("Sixel DCS started (direct)");
+                            trace!("Sixel DCS started (direct)");
                             self.dcs_handler = Some(DcsHandler::Sixel(
                                 SixelDecoder::new(),
                             ));
@@ -1109,7 +1109,7 @@ impl Terminal {
         }
 
         let payload = &self.apc_buffer[1..];
-        log::info!("Kitty APC received: {} bytes payload", payload.len());
+        log::trace!("Kitty APC received: {} bytes payload", payload.len());
 
         // Create new decoder if none exists
         if self.kitty_decoder.is_none() {

--- a/src/terminal/parser.rs
+++ b/src/terminal/parser.rs
@@ -745,7 +745,7 @@ impl<'a> Perform for Performer<'a> {
                                 false, // Sixel always moves cursor
                                 0,     // No explicit display cols
                                 0,     // No explicit display rows
-                                -1,    // z < 0: sixel survives text overwrites
+                                0,     // z=0: removed by text writes (yazi preview clear)
                                 0, 0,  // No cell offset
                                 0, 0, 0, 0, // No source rect
                             );

--- a/src/terminal/parser.rs
+++ b/src/terminal/parser.rs
@@ -120,6 +120,9 @@ pub struct Performer<'a> {
     pub pty_response: &'a mut Vec<u8>,
     pub dcs_handler: &'a mut Option<DcsHandler>,
     pub images: &'a mut ImageRegistry,
+    /// Newly produced or updated image IDs that need GPU texture re-upload.
+    /// Sixel/Kitty decoders push here when an image is registered.
+    pub dirty_image_ids: &'a mut Vec<u32>,
     /// Cell width (pixels)
     cell_width: u32,
     /// Cell height (pixels)
@@ -146,6 +149,7 @@ impl<'a> Performer<'a> {
         clipboard: &'a mut String,
         dcs_handler: &'a mut Option<DcsHandler>,
         images: &'a mut ImageRegistry,
+        dirty_image_ids: &'a mut Vec<u32>,
         cell_width: u32,
         cell_height: u32,
         current_dir: &'a mut Option<String>,
@@ -163,6 +167,7 @@ impl<'a> Performer<'a> {
             pty_response,
             dcs_handler,
             images,
+            dirty_image_ids,
             cell_width,
             cell_height,
             current_dir,
@@ -726,9 +731,15 @@ impl<'a> Perform for Performer<'a> {
                             last_frame_time: std::time::Instant::now(),
                         };
                         let img_id = self.images.insert(term_img);
+                        // Mark for GPU texture upload — without this the
+                        // renderer never sees the new pixel data and the
+                        // placement renders as a solid black rectangle.
+                        self.dirty_image_ids.push(img_id);
                         // Place image on grid
                         if let Some(image) = self.images.get(img_id) {
-                            self.grid.place_image(
+                            // Sixel is always non-overlay, so no placements
+                            // are superseded — ignore the returned vec.
+                            let _ = self.grid.place_image(
                                 img_id,
                                 image.width,
                                 image.height,

--- a/src/terminal/parser.rs
+++ b/src/terminal/parser.rs
@@ -659,7 +659,7 @@ impl<'a> Perform for Performer<'a> {
         match (action, intermediates) {
             // Sixel: DCS q or DCS P q
             ('q', []) | ('q', [b'0'..=b'9']) => {
-                info!("Sixel DCS started");
+                trace!("Sixel DCS started");
                 *self.dcs_handler = Some(DcsHandler::Sixel(SixelDecoder::new()));
             }
             // XTGETTCAP: DCS + q Pt ST

--- a/src/terminal/parser.rs
+++ b/src/terminal/parser.rs
@@ -709,7 +709,6 @@ impl<'a> Perform for Performer<'a> {
                     self.handle_decrqss(&buffer);
                 }
                 DcsHandler::Sixel(decoder) => {
-                    // Decode complete, register image
                     let id = self.images.next_id;
                     if let Some(sixel_img) = decoder.finish(id) {
                         info!(
@@ -737,9 +736,7 @@ impl<'a> Perform for Performer<'a> {
                         self.dirty_image_ids.push(img_id);
                         // Place image on grid
                         if let Some(image) = self.images.get(img_id) {
-                            // Sixel is always non-overlay, so no placements
-                            // are superseded — ignore the returned vec.
-                            let _ = self.grid.place_image(
+                            let superseded = self.grid.place_image(
                                 img_id,
                                 image.width,
                                 image.height,
@@ -748,10 +745,20 @@ impl<'a> Perform for Performer<'a> {
                                 false, // Sixel always moves cursor
                                 0,     // No explicit display cols
                                 0,     // No explicit display rows
-                                0,     // Sixel has no z-index
+                                -1,    // z < 0: sixel survives text overwrites
                                 0, 0,  // No cell offset
                                 0, 0, 0, 0, // No source rect
                             );
+                            // `mpv --vo=sixel` replays the same absolute
+                            // cell every frame because it resets the cursor
+                            // before each DCS. Reclaim the RGBA backing
+                            // buffer and GPU texture of the frame we just
+                            // superseded so neither the image registry nor
+                            // the texture cache grows unbounded.
+                            for old_id in superseded {
+                                self.images.remove(old_id);
+                                self.dirty_image_ids.push(old_id);
+                            }
                         }
                     }
                 }

--- a/src/terminal/sixel.rs
+++ b/src/terminal/sixel.rs
@@ -131,6 +131,7 @@ impl SixelDecoder {
     }
 
     /// Process one byte in streaming fashion
+    #[inline(always)]
     pub fn push(&mut self, byte: u8) {
         match self.state {
             State::Normal => self.handle_normal(byte),
@@ -141,6 +142,7 @@ impl SixelDecoder {
     }
 
     /// Handle normal state
+    #[inline(always)]
     fn handle_normal(&mut self, byte: u8) {
         match byte {
             b'#' => {
@@ -180,6 +182,7 @@ impl SixelDecoder {
     }
 
     /// Handle color command (#Pc or #Pc;Pu;Px;Py;Pz)
+    #[inline(always)]
     fn handle_color(&mut self, byte: u8) {
         match byte {
             b'0'..=b'9' | b';' => {
@@ -206,6 +209,7 @@ impl SixelDecoder {
     }
 
     /// Handle RLE count (!n)
+    #[inline(always)]
     fn handle_rle(&mut self, byte: u8) {
         match byte {
             b'0'..=b'9' => {
@@ -225,6 +229,7 @@ impl SixelDecoder {
     }
 
     /// Handle raster attributes ("Pan;Pad;Ph;Pv)
+    #[inline(always)]
     fn handle_raster_attr(&mut self, byte: u8) {
         match byte {
             b'0'..=b'9' | b';' => {
@@ -319,6 +324,7 @@ impl SixelDecoder {
 
     /// Draw Sixel pattern — hot path, called for every sixel data character.
     /// Writes directly to the pixel buffer without per-pixel ensure_size.
+    #[inline(always)]
     fn draw_sixel(&mut self, pattern: u8, count: u32) {
         let py_base = self.y * 6;
         let max_py = py_base + 5;
@@ -346,6 +352,7 @@ impl SixelDecoder {
     }
 
     /// Ensure image size
+    #[inline(always)]
     fn ensure_size(&mut self, new_w: u32, new_h: u32) {
         let need_resize = new_w > self.width || new_h > self.height;
         if !need_resize {

--- a/src/terminal/sixel.rs
+++ b/src/terminal/sixel.rs
@@ -317,34 +317,31 @@ impl SixelDecoder {
         }
     }
 
-    /// Draw Sixel pattern
+    /// Draw Sixel pattern — hot path, called for every sixel data character.
+    /// Writes directly to the pixel buffer without per-pixel ensure_size.
     fn draw_sixel(&mut self, pattern: u8, count: u32) {
+        let py_base = self.y * 6;
+        let max_py = py_base + 5;
+        let max_x = self.x + count;
+        // Single ensure_size for the entire run
+        self.ensure_size(max_x, max_py + 1);
+        let w = self.width;
+        let color = self.current_color;
+        let pixels = &mut self.pixels;
+        let len = pixels.len();
         for _ in 0..count {
-            // Draw 6-bit pattern as 6 vertical pixels
             let px = self.x;
-            let py_base = self.y * 6;
-
-            for bit in 0..6 {
-                if (pattern >> bit) & 1 != 0 {
-                    let py = py_base + bit;
-                    self.set_pixel(px, py, self.current_color);
+            if pattern != 0 {
+                for bit in 0u32..6 {
+                    if (pattern >> bit) & 1 != 0 {
+                        let idx = ((py_base + bit) * w + px) as usize;
+                        if idx < len {
+                            pixels[idx] = color;
+                        }
+                    }
                 }
             }
-
             self.x += 1;
-        }
-    }
-
-    /// Set pixel (expand buffer as needed)
-    fn set_pixel(&mut self, x: u32, y: u32, color: u8) {
-        // Expand image size
-        let new_w = x + 1;
-        let new_h = y + 1;
-        self.ensure_size(new_w, new_h);
-
-        let idx = (y * self.width + x) as usize;
-        if idx < self.pixels.len() {
-            self.pixels[idx] = color;
         }
     }
 
@@ -415,16 +412,25 @@ impl SixelDecoder {
             }
         };
 
-        // Convert palette indices to RGBA
-        let mut data = Vec::with_capacity(rgba_size);
-        for &idx in &self.pixels {
-            if idx == 255 {
-                // Transparent pixel
-                data.extend_from_slice(&[0, 0, 0, 0]);
+        // Convert palette indices to RGBA — pre-build a 256-entry RGBA LUT
+        // so the inner loop is a single indexed copy per pixel.
+        let mut lut = [[0u8; 4]; 256];
+        for (i, entry) in lut.iter_mut().enumerate() {
+            if i == 255 {
+                *entry = [0, 0, 0, 0]; // transparent
             } else {
-                let (r, g, b) = self.palette[idx as usize];
-                data.extend_from_slice(&[r, g, b, 255]);
+                let (r, g, b) = self.palette[i];
+                *entry = [r, g, b, 255];
             }
+        }
+        let mut data = vec![0u8; rgba_size];
+        for (i, &idx) in self.pixels.iter().enumerate() {
+            let rgba = &lut[idx as usize];
+            let off = i * 4;
+            data[off] = rgba[0];
+            data[off + 1] = rgba[1];
+            data[off + 2] = rgba[2];
+            data[off + 3] = rgba[3];
         }
 
         trace!(


### PR DESCRIPTION
## Summary
Four graphics-protocol bugs found while debugging issue #7 (mplayer fbdev2 playback) by exercising `chafa -f sixel`, `chafa -f kitty`, and `mpv --vo=kitty` on bcon.

- **Kitty graphics: per-chunk base64 decode** — chafa emits each chunk as a self-contained base64 unit with its own `=` padding. bcon was concatenating raw base64 across chunks and skipping `=` during decode, which leaked 2 leftover bits per chunk into the next, producing 600 extra bytes for a 640×480 RGBA image (2400 chunks × 2 bits). Now each chunk is decoded on arrival. Regression test added.
- **Kitty graphics: gate responses on client-provided id** — the protocol says terminals must not emit responses unless the client set `i=` or `I=`. chafa sets neither, so bcon's `OK` reply was leaking into the shell input as visible text. Introduced `Terminal::maybe_send_kitty_response` to collapse seven nearly-identical call sites into one gated helper.
- **Grid: keep the cursor out of placed image area** — `place_image` advanced the cursor onto the last row occupied by the image (both the scroll and non-scroll paths clamped to `rows - 1`). The very next `put_char` then called `remove_images_at_cell`, discarding the placement we had just created — observed as the second `chafa -f sixel` run rendering nothing. Unified the branch so the cursor always lands one row past the image, scrolling additionally if needed.
- **Grid: dedupe fully-covered overlay placements** — `mpv --vo=kitty` streams identically sized overlay frames (`a=T,C=1`) at the same cell without ever issuing a delete. bcon accumulated one placement and one ~3MB image per frame, stalling within ~4 seconds because the PTY read loop couldn't drain. `place_image` now returns the ids of any overlay placements fully covered by the new one at the same z-index, and the Kitty handler drops those ids from the image registry so GPU textures and RGBA buffers are reclaimed every frame.

Also marks sixel-decoded images with `dirty_image_ids.push(img_id)` so the renderer actually uploads the new texture — previously the sixel decode completed but no GPU upload ever ran, so the placement rendered as a solid black rectangle.

## Test plan
- [x] `cargo test --release terminal::kitty` — new chunked-base64 regression test passes
- [x] `chafa -f kitty test.png` displays the image with no `OK` reply leaking into the shell
- [x] `chafa -f sixel test.png` displays the image; running it a second time still displays
- [x] `mpv --no-audio --vo=kitty test.mp4` plays to completion without stalling (throughput is still heavy at full resolution; lower with `--vf=scale=480:-2,fps=15` for smoother playback)
- [ ] `mpv --no-audio --vo=sixel test.mp4` — **still broken** (DCS parser leaks sixel bytes as printable text mid-stream). Static sixel and Kitty graphics video are unaffected. Tracked as follow-up.

## Known follow-ups (not in this PR)
- sixel streaming from `mpv --vo=sixel` breaks the DCS parser mid-playback
- sixel palette index 255 collides with the decoder's "unpainted" sentinel — image pixels of color 255 render as transparent
- Kitty graphics throughput optimization (SIMD `rgb_to_rgba`, faster base64, shared-memory `t=s` path) to make full-resolution video smoother