### PR TITLE
feat(input): switch libinput to udev mode for hotplug support

### DIFF
--- a/src/input/evdev.rs
+++ b/src/input/evdev.rs
@@ -6,13 +6,14 @@
 #![allow(dead_code)]
 
 use anyhow::{anyhow, Result};
+use input::event::device::DeviceEvent;
 use input::event::keyboard::{KeyState, KeyboardEventTrait};
 use input::event::pointer::{Axis, ButtonState, PointerScrollEvent};
 use input::event::gesture::{
     GestureEventCoordinates, GestureEventTrait, GesturePinchEventTrait, GestureSwipeEvent,
     GesturePinchEvent,
 };
-use input::event::{Event, GestureEvent, PointerEvent};
+use input::event::{Event, EventTrait, GestureEvent, PointerEvent};
 use input::{Device as LibinputDevice, Libinput, LibinputInterface};
 use log::{debug, info, warn};
 use std::collections::HashMap;
@@ -226,12 +227,17 @@ pub struct EvdevKeyboard {
     gesture_swipe_fingers: i32,
     /// Gesture state: accumulated pinch scale
     gesture_pinch_scale: f64,
+    /// Mouse/touchpad configuration, retained to apply to hotplugged devices
+    mouse_config: MouseConfig,
 }
 
 impl EvdevKeyboard {
     /// Initialize evdev input
     ///
-    /// Scan /dev/input/event* and add devices to libinput.
+    /// Create a libinput context in udev mode so devices added after startup
+    /// (USB hotplug, uinput virtual devices, etc.) are picked up automatically.
+    /// Existing devices and any later hotplug events are delivered as
+    /// `DeviceEvent::Added` / `Removed` through `process_raw_events`.
     /// Set up keymap with xkbcommon.
     /// screen_width/height used for mouse coordinate clamping.
     pub fn new(
@@ -240,34 +246,16 @@ impl EvdevKeyboard {
         kb_config: &KeyboardInputConfig,
         mouse_config: &MouseConfig,
     ) -> Result<Self> {
-        // Create libinput context
-        let mut input = Libinput::new_from_path(InputInterface);
+        // Create libinput context in udev mode and activate it on seat0.
+        // udev_assign_seat() must be called exactly once per context; it
+        // activates event delivery for existing devices and enables hotplug
+        // monitoring for future ones.
+        let mut input = Libinput::new_with_udev(InputInterface);
+        input
+            .udev_assign_seat("seat0")
+            .map_err(|_| anyhow!("Failed to assign udev seat0 to libinput"))?;
 
-        // Scan and add devices from /dev/input/event*
-        let mut device_count = 0;
-        for entry in
-            std::fs::read_dir("/dev/input").map_err(|e| anyhow!("Cannot scan /dev/input: {}", e))?
-        {
-            let entry = entry?;
-            let path = entry.path();
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if name.starts_with("event") {
-                let path_str = path.to_str().unwrap_or("");
-                if let Some(mut device) = input.path_add_device(path_str) {
-                    debug!("Input device added: {}", path_str);
-                    configure_touchpad(&mut device, mouse_config);
-                    device_count += 1;
-                }
-            }
-        }
-
-        if device_count == 0 {
-            return Err(anyhow!(
-                "No input devices found. Check permissions for /dev/input/event*."
-            ));
-        }
-
-        info!("evdev: {} input devices added", device_count);
+        info!("evdev: libinput udev context initialized (seat0)");
 
         // Get libinput fd
         let fd = input.as_raw_fd();
@@ -355,6 +343,7 @@ impl EvdevKeyboard {
             gesture_swipe_dy: 0.0,
             gesture_swipe_fingers: 0,
             gesture_pinch_scale: 1.0,
+            mouse_config: mouse_config.clone(),
         })
     }
 
@@ -369,37 +358,19 @@ impl EvdevKeyboard {
         kb_config: &KeyboardInputConfig,
         mouse_config: &MouseConfig,
     ) -> Result<Self> {
-        // Create libinput context with seat-based interface
+        // Create libinput context with seat-based interface, in udev mode so
+        // hotplugged devices (USB, uinput virtual devices, etc.) are picked up
+        // automatically after startup. Device enumeration happens via
+        // DeviceEvent::Added in process_raw_events.
         let interface = SeatInputInterface {
             session: session.clone(),
         };
-        let mut input = Libinput::new_from_path(interface);
+        let mut input = Libinput::new_with_udev(interface);
+        input
+            .udev_assign_seat("seat0")
+            .map_err(|_| anyhow!("Failed to assign udev seat0 to libinput (libseat)"))?;
 
-        // Scan and add devices from /dev/input/event*
-        let mut device_count = 0;
-        for entry in
-            std::fs::read_dir("/dev/input").map_err(|e| anyhow!("Cannot scan /dev/input: {}", e))?
-        {
-            let entry = entry?;
-            let path = entry.path();
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if name.starts_with("event") {
-                let path_str = path.to_str().unwrap_or("");
-                if let Some(mut device) = input.path_add_device(path_str) {
-                    debug!("Input device added via libseat: {}", path_str);
-                    configure_touchpad(&mut device, mouse_config);
-                    device_count += 1;
-                }
-            }
-        }
-
-        if device_count == 0 {
-            return Err(anyhow!(
-                "No input devices found via libseat. Check seatd/logind permissions."
-            ));
-        }
-
-        info!("evdev: {} input devices added via libseat", device_count);
+        info!("evdev: libinput udev context initialized via libseat (seat0)");
 
         // Get libinput fd
         let fd = input.as_raw_fd();
@@ -480,6 +451,7 @@ impl EvdevKeyboard {
             held_keys: HashMap::new(),
             repeat_delay_ms: kb_config.repeat_delay,
             repeat_rate_ms: kb_config.repeat_rate,
+            mouse_config: mouse_config.clone(),
             gesture_swipe_dx: 0.0,
             gesture_swipe_dy: 0.0,
             gesture_swipe_fingers: 0,
@@ -766,6 +738,28 @@ impl EvdevKeyboard {
                         _ => {}
                     }
                 }
+                Event::Device(dev_event) => match dev_event {
+                    DeviceEvent::Added(ev) => {
+                        let mut device = ev.device();
+                        debug!("Input device added: {:?}", device.name());
+                        configure_touchpad(&mut device, &self.mouse_config);
+                    }
+                    DeviceEvent::Removed(ev) => {
+                        debug!("Input device removed: {:?}", ev.device().name());
+                        // Simple cleanup: clear all held keys and modifier
+                        // state. If the removed device was a keyboard with
+                        // keys held down, its Released events never arrive,
+                        // which would otherwise stick keys in self.held_keys
+                        // and generate phantom key repeats. Suspending bcon
+                        // does the same thing, so users are already used to
+                        // this behavior on transient state loss.
+                        self.held_keys.clear();
+                        self.shift_pressed = false;
+                        self.ctrl_pressed = false;
+                        self.alt_pressed = false;
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
         }


### PR DESCRIPTION
## Problem

`bcon` currently scans `/dev/input/event*` once at startup via
`Libinput::new_from_path` + `path_add_device`. Devices that appear
after startup are never picked up:

- USB keyboards plugged in after `bcon` starts don't work.
- USB mice plugged in after `bcon` starts don't work.
- Touchpads connected after startup never get the touchpad
  configuration (tap-to-click, natural-scroll, disable-while-typing)
  applied.

## Fix

Switch both constructors to udev mode:

```rust
let mut input = Libinput::new_with_udev(interface);
input.udev_assign_seat("seat0")?;
```

This makes `libinput` monitor udev for device add/remove and emit
`DeviceEvent::Added` / `DeviceEvent::Removed`. Existing devices are
also delivered as `Added` after `udev_assign_seat`, so the one-shot
scan loop is no longer needed.

A new `Event::Device` match arm in `process_raw_events` handles the
device lifecycle:

- `DeviceEvent::Added` — call `configure_touchpad` on the new device,
  so hotplugged touchpads get the same tap-to-click / natural-scroll /
  disable-while-typing settings as boot-time ones.
- `DeviceEvent::Removed` — clear `held_keys` and modifier state. If a
  keyboard is unplugged while keys are held down, the corresponding
  `Released` events never arrive; without cleanup those keys stay in
  `held_keys` and generate phantom key repeats in the repeat loop.
  `suspend()` already performs the same cleanup, so users are already
  accustomed to this transient-state-loss behavior.

`MouseConfig` is cloned into a new struct field so the `Added` handler
can apply touchpad config long after the constructor returns.

Both constructors are migrated:

- `EvdevKeyboard::new` — direct device access path.
- `EvdevKeyboard::new_with_seat` — libseat path.

No `Cargo.toml` changes: `input = "0.8"` already enables the `udev`
feature by default.

## Testing

Verified on Arch Linux (kernel 6.19.11) with `bcon@tty2.service`.

### 1. Startup device enumeration via udev

Debug log on service start shows all existing devices delivered as
`DeviceEvent::Added` events:

```
evdev: libinput udev context initialized (seat0)
Input device added: "Power Button"
Input device added: "QEMU QEMU USB Tablet"
Input device added: "AT Translated Set 2 keyboard"
Input device added: "VirtualPS/2 VMware VMMouse"
Input device added: "VirtualPS/2 VMware VMMouse"
```

### 2. Hotplug: uinput device created after startup

To exercise the hotplug path in a QEMU guest where physical USB
hotplug isn't easily simulated, a uinput virtual keyboard was
created after `bcon` was already running, and `ctrl+0` (font-reset
action) was injected through it:

```
Input device added: "<uinput virtual keyboard>"
EmojiAtlas: cache cleared due to font size change
Framebuffer created: id=43, 1280x800, stride=5120
Input device removed: "<uinput virtual keyboard>"
```

The `EmojiAtlas: cache cleared` line and the framebuffer redraw
confirm the `font-reset` action fired end-to-end through the new
hotplugged device — something the previous code path made impossible.

### 3. VT switch + suspend/resume

`Ctrl+Alt+F1` → tty1 (~27 s) → `Ctrl+Alt+F2` back to bcon. `libinput`
re-emits Removed + Added for all devices on resume, which re-applies
`configure_touchpad` cleanly:

```
VT release requested
Suspending libinput
VT released
... (27 s on tty1) ...
VT acquire
Resuming libinput
VT acquired
Input device removed: "Power Button"   / ... (5 devices)
Input device added:   "Power Button"   / ... (5 devices)
```

Pane tree and on-screen state are preserved across the switch.

### 4. Existing functionality — regression pass

- Screen rendering, login prompt, PTY echo ✓
- Keyboard and mouse input via physical input devices ✓
- Japanese IME input (Ctrl+Space commit, preedit display) ✓
- Pane split (`Ctrl+Shift+O`, `Ctrl+Shift+Enter`) ✓
- Font scaling (`Ctrl+Minus`) with visible size change ✓

### 5. Unit tests

```
cargo test
...
test result: ok. 44 passed; 0 failed; 1 ignored
```

## Not yet tested

- Physical USB keyboard hotplug on real hardware (planned for
  follow-up; the test environment is QEMU/KVM which can't trivially
  simulate USB hotplug from the guest's point of view).
- Stuck-key scenario where a keyboard is physically unplugged
  mid-keypress. The current simple cleanup (clear all held state on
  any device removal) is a conservative choice that may very briefly
  reset modifier state on uinput-originated short-lived devices too;
  a more surgical per-device cleanup could be added later if it
  becomes a problem in practice.